### PR TITLE
Created reservation and traveler controllers with create endpoints

### DIFF
--- a/WonderPlane.Server/Controllers/ReservationController.cs
+++ b/WonderPlane.Server/Controllers/ReservationController.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using WonderPlane.Server.Models;
+using WonderPlane.Shared;
+
+namespace WonderPlane.Server.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class ReservationController : ControllerBase
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public ReservationController(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    [HttpPost]
+    [Route("create")]
+    public async Task<IActionResult> CreateReservation(Reservation reservation)
+    {
+        var responseApi = new ResponseAPI<int>();
+
+        try
+        {
+            if (reservation.RegisteredUserId.HasValue)
+            {
+                var userExists = await _dbContext.Users.AnyAsync(u => u.Id == reservation.RegisteredUserId.Value);
+                if (!userExists)
+                {
+                    responseApi.EsCorrecto = false;
+                    responseApi.Mensaje = $"El usuario registrado con ID {reservation.RegisteredUserId} no existe.";
+                    return BadRequest(responseApi);
+                }
+            }
+
+            var newReservation = new Reservation
+            {
+                ReservationDate = reservation.ReservationDate,
+                PaymentLimitDate = reservation.PaymentLimitDate,
+                ReservationStatus = ReservationStatus.Reserved, 
+                RegisteredUserId = reservation.RegisteredUserId
+            };
+
+            _dbContext.Reservations.Add(newReservation);
+            await _dbContext.SaveChangesAsync();
+
+            responseApi.Data = newReservation.Id;
+            responseApi.EsCorrecto = true;
+            responseApi.Mensaje = "Reserva creada correctamente.";
+            return Ok(responseApi);
+        }
+        catch (DbUpdateException dbEx)
+        {
+            responseApi.EsCorrecto = false;
+            responseApi.Mensaje = $"Error de base de datos: {dbEx.Message}";
+            return StatusCode(500, responseApi);
+        }
+        catch (Exception ex)
+        {
+            responseApi.EsCorrecto = false;
+            responseApi.Mensaje = $"Error inesperado: {ex.Message}";
+            return StatusCode(500, responseApi);
+        }
+    }
+}

--- a/WonderPlane.Server/Controllers/TravelerController.cs
+++ b/WonderPlane.Server/Controllers/TravelerController.cs
@@ -1,0 +1,71 @@
+﻿using WonderPlane.Server.Models;
+using WonderPlane.Shared;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace WonderPlane.Server.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class TravelerController : ControllerBase
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public TravelerController(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    [HttpPost]
+    [Route("create")]
+    public async Task<IActionResult> CreateTraveler([FromBody] Traveler traveler)
+    {
+        var responseApi = new ResponseAPI<int>();
+        try
+        {
+            var existingTraveler = await _dbContext.Travelers
+                .FirstOrDefaultAsync(t => t.Document == traveler.Document);
+
+            if (existingTraveler != null)
+            {
+                responseApi.EsCorrecto = false;
+                responseApi.Mensaje = "Ya existe un viajero con este documento.";
+                return BadRequest(responseApi);
+            }
+
+            if (traveler.RegisteredUserId.HasValue)
+            {
+                var registeredUserExists = await _dbContext.Users
+                    .AnyAsync(u => u.Id == traveler.RegisteredUserId.Value);
+
+                if (!registeredUserExists)
+                {
+                    responseApi.EsCorrecto = false;
+                    responseApi.Mensaje = "El usuario registrado especificado no existe.";
+                    return BadRequest(responseApi);
+                }
+            }
+
+            _dbContext.Travelers.Add(traveler);
+            await _dbContext.SaveChangesAsync();
+
+            responseApi.Data = traveler.Id;
+            responseApi.EsCorrecto = true;
+            responseApi.Mensaje = "Viajero creado correctamente.";
+            return Ok(responseApi);
+        }
+        catch (DbUpdateException dbEx)
+        {
+            responseApi.EsCorrecto = false;
+            responseApi.Mensaje = $"Error de base de datos: {dbEx.Message}";
+            return StatusCode(500, responseApi);
+        }
+        catch (Exception ex)
+        {
+            responseApi.EsCorrecto = false;
+            responseApi.Mensaje = $"Error inesperado: {ex.Message}";
+            return StatusCode(500, responseApi);
+        }
+    }
+
+}

--- a/WonderPlane.Server/Models/Reservation.cs
+++ b/WonderPlane.Server/Models/Reservation.cs
@@ -17,7 +17,7 @@ public class Reservation
     public required DateTime PaymentLimitDate { get; set; }
 
     [Required(ErrorMessage = "El estado de la reserva es obligatorio.")]
-    public required ReservationStatus ReservationStatus { get; set; }
+    public ReservationStatus ReservationStatus { get; set; }
 
     public int? RegisteredUserId { get; set; }
     public User? RegisteredUser { get; set; }


### PR DESCRIPTION
This pull request introduces new API controllers for handling reservations and travelers, along with a minor modification to the `Reservation` model. The most important changes include the addition of `ReservationController` and `TravelerController`, as well as an update to the `ReservationStatus` property in the `Reservation` model.

New API Controllers:

* [`WonderPlane.Server/Controllers/ReservationController.cs`](diffhunk://#diff-adeb446b4fe7298bc19c156c6f69bc5f8750e1ddc7221892b4d0d70f85ac98aaR1-R67): Added a new `ReservationController` to handle reservation creation with appropriate validation and error handling.
* [`WonderPlane.Server/Controllers/TravelerController.cs`](diffhunk://#diff-217033a4d3c7982226dc1163f5163d3dedea53a90d86ba44de04bbf360ab3378R1-R71): Added a new `TravelerController` to handle traveler creation, including checks for existing travelers and user validation.

Model Update:

* [`WonderPlane.Server/Models/Reservation.cs`](diffhunk://#diff-f8f4fc48fd0abcb337abd29418e39c66b7a8cd63209f5409ff61b45322082512L20-R20): Changed the `ReservationStatus` property to be non-required, allowing it to have a default value.